### PR TITLE
Put ReportReserved back in df.conf

### DIFF
--- a/collectd/files/df.conf
+++ b/collectd/files/df.conf
@@ -29,6 +29,7 @@ LoadPlugin df
 {%- endif %}
       IgnoreSelected "{{ collectd_settings.plugins.df.IgnoreSelected|lower }}"
       ReportByDevice "{{ collectd_settings.plugins.df.ReportByDevice|lower }}"
+      ReportReserved "{{ collectd_settings.plugins.df.ReportReserved|lower }}"
       ReportInodes "{{ collectd_settings.plugins.df.ReportInodes|lower }}"
       ValuesPercentage "{{ collectd_settings.plugins.df.ValuesPercentage|lower }}"
 </Plugin>


### PR DESCRIPTION
ReportReserved setting has been removed in 5.5.1 but only gives an error on startup, so leave it in.
